### PR TITLE
Allow uneven wavelength steps in `p_abs_single()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pahwq
 Title: Calculate site-specific water quality guidelines for PAHs
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Andy", "Teucher", , "andy.teucher@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7840-692X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# pahwq 0.3.1
+
+* `p_abs_single()` now accomodates unequal wavelength intervals.
+
 # pahwq 0.3.0
 
 * Rename PAH -> PAC in sensitivity analysis

--- a/R/ptlm.R
+++ b/R/ptlm.R
@@ -133,8 +133,6 @@ p_abs_single <- function(
     )
   }
 
-  delta_wavelength <- max(diff(exposure$wl))
-
   # Eqn. 3-1 in ARIS 2023
   unit_conversion_constant <- 8.3594e-12 # μW/cm2/nm -> mole photon/mole chem/sec
 
@@ -156,6 +154,8 @@ p_abs_single <- function(
     by.y = "wavelength"
   )
 
+  delta_wavelength <- c(1, diff(exposure$wl))
+
   res_mat <- as.matrix(exposure)
 
   # Eq 3-2, ARIS report
@@ -163,10 +163,10 @@ p_abs_single <- function(
     setdiff(colnames(res_mat), c("wl", "molar_absorption"))
   ] * # irradiance
     res_mat[, "wl"] * # wavelength
-    res_mat[, "molar_absorption"] # molar absorption of pah
+    res_mat[, "molar_absorption"] * # molar absorption of pah
+    delta_wavelength
 
   sum(Pabs_mat) *
-    delta_wavelength *
     unit_conversion_constant *
     time_multiplier
 }

--- a/tests/testthat/test-ptlm.R
+++ b/tests/testthat/test-ptlm.R
@@ -22,7 +22,10 @@ test_that("phototoxic_benchmark works", {
   )
 
   expect_snapshot(
-    round(phototoxic_benchmark(590, pah = "Benzo(a)pyrene", narc_bench = 450), 2)
+    round(
+      phototoxic_benchmark(590, pah = "Benzo(a)pyrene", narc_bench = 450),
+      2
+    )
   )
 
   expect_snapshot(phototoxic_benchmark(590), error = TRUE)
@@ -55,11 +58,14 @@ test_that("phototoxic_benchmark deals with time multiplier", {
 
   expect_equal(
     phototoxic_benchmark(res, "Anthracene", time_multiplier = 4),
-    phototoxic_benchmark(p_abs(res, "Anthracene", time_multiplier = 4), "Anthracene")
+    phototoxic_benchmark(
+      p_abs(res, "Anthracene", time_multiplier = 4),
+      "Anthracene"
+    )
   )
 })
 
-test_that("narcotic_benchmark works",{
+test_that("narcotic_benchmark works", {
   expect_snapshot(
     round(narcotic_benchmark("C1-Chrysenes"), 2)
   )
@@ -70,10 +76,13 @@ test_that("narcotic_benchmark works",{
 
 test_that("Pabs errors correctly", {
   expect_error(p_abs(1, "Anthracene"), "tuv_results")
-  expect_error(p_abs(
-    structure(list(), class = c("tuv_results", "data.frame")),
-    "foo"
-  ), "must be one of")
+  expect_error(
+    p_abs(
+      structure(list(), class = c("tuv_results", "data.frame")),
+      "foo"
+    ),
+    "must be one of"
+  )
 })
 
 test_that("The whole shebang works", {
@@ -234,7 +243,7 @@ test_that("p_abs_single works", {
 
   expect_equal(
     # 8 hours
-    round(p_abs_single(df, "anthracene", 3600*8), 5),
+    round(p_abs_single(df, "anthracene", 3600 * 8), 5),
     48.33764
   )
 
@@ -257,7 +266,15 @@ test_that("p_abs_single works", {
     round(p_abs_single(data.frame(wl = 1, i = "a"), "anthracene"), 5),
     "Column 2 must be numeric"
   )
+})
 
+test_that("p_abs_single() works when wavelength diffs > 1", {
+  df <- data.frame(
+    wl = c(305, 320, 380, 400, 401, 402),
+    i = c(0.19, 7.40, 2.60, 205.00, 205.00, 205.00)
+  )
+
+  expect_equal(round(p_abs_single(df, "anthracene"), 5), 0.00318)
 })
 
 test_that("narcotic_cwqg works", {
@@ -302,7 +319,6 @@ test_that("phototoxic_cwqg works with tuv results", {
     phototoxic_cwqg(res, "Anthracene") * acr(),
     phototoxic_benchmark(res, "Anthracene")
   )
-
 })
 
 test_that("phototoxic_cwqg works with tuv results (Added chemicals to nlc50, #53); ", {
@@ -324,5 +340,4 @@ test_that("phototoxic_cwqg works with tuv results (Added chemicals to nlc50, #53
     phototoxic_cwqg(res, "C2-benzopyrenes") * acr(),
     phototoxic_benchmark(res, "C2-benzopyrenes")
   )
-
 })


### PR DESCRIPTION
Previously `p_abs_single()` assumed evenly spaced wavelengths in experimental irradiance data. This PR allows unevenly spaced wavelengths. (Ref: Eqn 3-1 ARIS 2023, Eqn 101 draft SCD)